### PR TITLE
Add the `lints` topic to the `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,5 +3,8 @@ description: A completionist set of lint rules, aligned with Dart SDK versions.
 version: 3.1.0-0
 repository: https://github.com/mockturtl/tidy
 
+topics:
+  - lints
+
 environment:
   sdk: '>=3.1.0-0 <4.0.0'


### PR DESCRIPTION
Adds the `lints` [topic](https://dart.dev/tools/pub/pubspec#topics) to the pubspec to increase discovery, as suggested in the [`package:lints` README](https://github.com/dart-lang/lints/blob/4b79906085d48fc4eee241a80e1a1b177dbdaf23/README.md?plain=1#L34-L38).